### PR TITLE
fix: bump python version to 3.14

### DIFF
--- a/.github/workflows/lint_format_checker.yaml
+++ b/.github/workflows/lint_format_checker.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.14" ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,6 @@
 # This workflow use pytest:
 #  - Install Python dependencies.
-#  - Run pytest for each of the supported Python versions ["3.8", "3.9", "3.10"]. 
+#  - Run pytest for each of the supported Python versions ["3.14"]. 
 # Running pytest with -m "no docker" to disable test that require a docker installation.
 
 name: Pytest.
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.14"]
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.11-bullseye as base
+FROM python:3.14-bookworm as base
 FROM base as builder
 RUN mkdir /install
 WORKDIR /install
 COPY requirement.txt /requirement.txt
 RUN pip install --prefix=/install -r /requirement.txt
 
-FROM golang:1.22-alpine AS go-build-env
+FROM golang:1.26-alpine AS go-build-env
 RUN go install -v github.com/projectdiscovery/dnsx/cmd/dnsx@latest
 
 FROM base
@@ -16,4 +16,4 @@ ENV PYTHONPATH=/app
 COPY agent /app/agent
 COPY ostorlab.yaml /app/agent/ostorlab.yaml
 WORKDIR /app
-CMD ["python3.11", "/app/agent/dnsx_agent.py"]
+CMD ["python", "/app/agent/dnsx_agent.py"]


### PR DESCRIPTION
## Changes

- bump python version to 3.14
- upgrade go version of the base image

## Successful build

<img width="522" height="55" alt="image" src="https://github.com/user-attachments/assets/7030fa6c-26e4-4a6e-b054-83aca1ebedb0" />

## Successful scan

<img width="1134" height="733" alt="image" src="https://github.com/user-attachments/assets/504ac629-53e3-4265-adb2-a93b28672744" />
