### PR TITLE
fix: configure explicit DNS resolvers and exclude OpenDns

### DIFF
--- a/agent/dnsx_agent.py
+++ b/agent/dnsx_agent.py
@@ -26,6 +26,16 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 OUTPUT_SUFFIX = ".json"
+_DNSX_RESOLVERS: str = ",".join(
+    (
+        "1.1.1.1",  # Cloudflare primary.
+        "1.0.0.1",  # Cloudflare secondary.
+        "8.8.8.8",  # Google Public DNS primary.
+        "8.8.4.4",  # Google Public DNS secondary.
+        "9.9.9.9",  # Quad9 primary.
+        "149.112.112.112",  # Quad9 secondary.
+    )
+)
 
 
 class DnsxAgent(agent.Agent, persist_mixin.AgentPersistMixin):
@@ -114,9 +124,9 @@ class DnsxAgent(agent.Agent, persist_mixin.AgentPersistMixin):
         else:
             logger.warning("Empty result file for domain %s", domain)
 
-    def _prepare_command(self, domain, wordlist: Optional[str]) -> List[str]:
+    def _prepare_command(self, domain: str, wordlist: str | None) -> list[str]:
         """Prepare dnsx command."""
-        command = [
+        command: list[str] = [
             "dnsx",
             "-silent",
             "-a",
@@ -128,6 +138,8 @@ class DnsxAgent(agent.Agent, persist_mixin.AgentPersistMixin):
             "-mx",
             "-resp",
             "-json",
+            "-r",
+            _DNSX_RESOLVERS,
             "-d",
             domain,
         ]
@@ -153,7 +165,7 @@ class DnsxAgent(agent.Agent, persist_mixin.AgentPersistMixin):
             else:
                 logger.warning("Empty result file for domain %s", domain)
 
-    def _prepare_command_resolve(self, domain_file) -> List[str]:
+    def _prepare_command_resolve(self, domain_file: str) -> list[str]:
         """Prepare dnsx command."""
         return [
             "dnsx",
@@ -167,6 +179,8 @@ class DnsxAgent(agent.Agent, persist_mixin.AgentPersistMixin):
             "-mx",
             "-resp",
             "-json",
+            "-r",
+            _DNSX_RESOLVERS,
             "-l",
             domain_file,
         ]

--- a/tests/dnsx_agent_test.py
+++ b/tests/dnsx_agent_test.py
@@ -8,18 +8,6 @@ from ostorlab.agent.message import message
 from agent import dnsx_agent
 
 
-_DNSX_RESOLVERS: str = ",".join(
-    (
-        "1.1.1.1",
-        "1.0.0.1",
-        "8.8.8.8",
-        "8.8.4.4",
-        "9.9.9.9",
-        "149.112.112.112",
-    )
-)
-
-
 def testAgentDnsx_whenDomainNameAssetWithWordlist_runScan(
     scan_message, test_agent1, agent_mock, agent_persist_mock, fp
 ):
@@ -38,7 +26,7 @@ def testAgentDnsx_whenDomainNameAssetWithWordlist_runScan(
             "-resp",
             "-json",
             "-r",
-            _DNSX_RESOLVERS,
+            dnsx_agent._DNSX_RESOLVERS,
             "-l",
             fp.any(max=1),
         ],
@@ -50,7 +38,7 @@ def testAgentDnsx_whenDomainNameAssetWithWordlist_runScan(
     )
     fp.register(
         "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json "
-        f"-r {_DNSX_RESOLVERS} -d ostorlab.co "
+        f"-r {dnsx_agent._DNSX_RESOLVERS} -d ostorlab.co "
         "-w agent/wordlists/100_list.txt",
         stdout='{"host":"www.ostorlab.co","resolver":["1.0.0.1:53","8.8.8.8:53","8.8.4.4:53","1.1.1.1:53"],'
         '"a":["164.90.232.184","3.67.255.218"],'
@@ -84,7 +72,7 @@ def testAgentDnsx_whenDomainNameAsset_runScan(
             "-resp",
             "-json",
             "-r",
-            _DNSX_RESOLVERS,
+            dnsx_agent._DNSX_RESOLVERS,
             "-l",
             fp.any(max=1),
         ],
@@ -96,7 +84,7 @@ def testAgentDnsx_whenDomainNameAsset_runScan(
     )
     fp.register(
         "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json "
-        f"-r {_DNSX_RESOLVERS} -d ostorlab.co "
+        f"-r {dnsx_agent._DNSX_RESOLVERS} -d ostorlab.co "
         "-w agent/wordlists/100_list.txt",
         stdout='{"host":"www.ostorlab.co","resolver":["1.0.0.1:53","8.8.8.8:53","8.8.4.4:53","1.1.1.1:53"],'
         '"a":["164.90.232.184","3.67.255.218"],'
@@ -130,7 +118,7 @@ def testAgentDnsx_whenMaxSubDomainsSet_runScan(
             "-resp",
             "-json",
             "-r",
-            _DNSX_RESOLVERS,
+            dnsx_agent._DNSX_RESOLVERS,
             "-l",
             fp.any(max=1),
         ],
@@ -142,7 +130,7 @@ def testAgentDnsx_whenMaxSubDomainsSet_runScan(
     )
     fp.register(
         "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json "
-        f"-r {_DNSX_RESOLVERS} -d ostorlab.co "
+        f"-r {dnsx_agent._DNSX_RESOLVERS} -d ostorlab.co "
         "-w agent/wordlists/100_list.txt",
         stdout='{"host":"www.ostorlab.co","resolver":["1.0.0.1:53","8.8.8.8:53","8.8.4.4:53","1.1.1.1:53"],'
         '"a":["164.90.232.184","3.67.255.218"],'
@@ -180,7 +168,7 @@ def testAgentDnsx_withDomainScopeArgAndDomainMessageInScope_runScan(
             "-resp",
             "-json",
             "-r",
-            _DNSX_RESOLVERS,
+            dnsx_agent._DNSX_RESOLVERS,
             "-l",
             fp.any(max=1),
         ],
@@ -192,7 +180,7 @@ def testAgentDnsx_withDomainScopeArgAndDomainMessageInScope_runScan(
     )
     fp.register(
         "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json "
-        f"-r {_DNSX_RESOLVERS} -d ostorlab.co "
+        f"-r {dnsx_agent._DNSX_RESOLVERS} -d ostorlab.co "
         "-w agent/wordlists/100_list.txt",
         stdout='{"host":"www.ostorlab.co","resolver":["1.0.0.1:53","8.8.8.8:53","8.8.4.4:53","1.1.1.1:53"],'
         '"a":["164.90.232.184","3.67.255.218"],'
@@ -233,7 +221,7 @@ def testAgentDnsx_withDomainScopeArgAndDomainMessageNotInScope_targetShouldNotBe
             "-resp",
             "-json",
             "-r",
-            _DNSX_RESOLVERS,
+            dnsx_agent._DNSX_RESOLVERS,
             "-l",
             fp.any(max=1),
         ],
@@ -245,7 +233,7 @@ def testAgentDnsx_withDomainScopeArgAndDomainMessageNotInScope_targetShouldNotBe
     )
     fp.register(
         "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json "
-        f"-r {_DNSX_RESOLVERS} -d ostorlab.co "
+        f"-r {dnsx_agent._DNSX_RESOLVERS} -d ostorlab.co "
         "-w agent/wordlists/100_list.txt",
         stdout='{"host":"www.ostorlab.co","resolver":["1.0.0.1:53","8.8.8.8:53","8.8.4.4:53","1.1.1.1:53"],'
         '"a":["164.90.232.184","3.67.255.218"],'

--- a/tests/dnsx_agent_test.py
+++ b/tests/dnsx_agent_test.py
@@ -8,6 +8,18 @@ from ostorlab.agent.message import message
 from agent import dnsx_agent
 
 
+_DNSX_RESOLVERS: str = ",".join(
+    (
+        "1.1.1.1",
+        "1.0.0.1",
+        "8.8.8.8",
+        "8.8.4.4",
+        "9.9.9.9",
+        "149.112.112.112",
+    )
+)
+
+
 def testAgentDnsx_whenDomainNameAssetWithWordlist_runScan(
     scan_message, test_agent1, agent_mock, agent_persist_mock, fp
 ):
@@ -25,6 +37,8 @@ def testAgentDnsx_whenDomainNameAssetWithWordlist_runScan(
             "-mx",
             "-resp",
             "-json",
+            "-r",
+            _DNSX_RESOLVERS,
             "-l",
             fp.any(max=1),
         ],
@@ -35,7 +49,8 @@ def testAgentDnsx_whenDomainNameAssetWithWordlist_runScan(
         '"has_internal_ips":false,"status_code":"NOERROR","timestamp":"2022-04-05T17:25:59.876762366+02:00"}',
     )
     fp.register(
-        "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json -d ostorlab.co "
+        "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json "
+        f"-r {_DNSX_RESOLVERS} -d ostorlab.co "
         "-w agent/wordlists/100_list.txt",
         stdout='{"host":"www.ostorlab.co","resolver":["1.0.0.1:53","8.8.8.8:53","8.8.4.4:53","1.1.1.1:53"],'
         '"a":["164.90.232.184","3.67.255.218"],'
@@ -68,6 +83,8 @@ def testAgentDnsx_whenDomainNameAsset_runScan(
             "-mx",
             "-resp",
             "-json",
+            "-r",
+            _DNSX_RESOLVERS,
             "-l",
             fp.any(max=1),
         ],
@@ -78,7 +95,8 @@ def testAgentDnsx_whenDomainNameAsset_runScan(
         '"has_internal_ips":false,"status_code":"NOERROR","timestamp":"2022-04-05T17:25:59.876762366+02:00"}',
     )
     fp.register(
-        "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json -d ostorlab.co "
+        "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json "
+        f"-r {_DNSX_RESOLVERS} -d ostorlab.co "
         "-w agent/wordlists/100_list.txt",
         stdout='{"host":"www.ostorlab.co","resolver":["1.0.0.1:53","8.8.8.8:53","8.8.4.4:53","1.1.1.1:53"],'
         '"a":["164.90.232.184","3.67.255.218"],'
@@ -111,6 +129,8 @@ def testAgentDnsx_whenMaxSubDomainsSet_runScan(
             "-mx",
             "-resp",
             "-json",
+            "-r",
+            _DNSX_RESOLVERS,
             "-l",
             fp.any(max=1),
         ],
@@ -121,7 +141,8 @@ def testAgentDnsx_whenMaxSubDomainsSet_runScan(
         '"has_internal_ips":false,"status_code":"NOERROR","timestamp":"2022-04-05T17:25:59.876762366+02:00"}',
     )
     fp.register(
-        "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json -d ostorlab.co "
+        "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json "
+        f"-r {_DNSX_RESOLVERS} -d ostorlab.co "
         "-w agent/wordlists/100_list.txt",
         stdout='{"host":"www.ostorlab.co","resolver":["1.0.0.1:53","8.8.8.8:53","8.8.4.4:53","1.1.1.1:53"],'
         '"a":["164.90.232.184","3.67.255.218"],'
@@ -158,6 +179,8 @@ def testAgentDnsx_withDomainScopeArgAndDomainMessageInScope_runScan(
             "-mx",
             "-resp",
             "-json",
+            "-r",
+            _DNSX_RESOLVERS,
             "-l",
             fp.any(max=1),
         ],
@@ -168,7 +191,8 @@ def testAgentDnsx_withDomainScopeArgAndDomainMessageInScope_runScan(
         '"has_internal_ips":false,"status_code":"NOERROR","timestamp":"2022-04-05T17:25:59.876762366+02:00"}',
     )
     fp.register(
-        "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json -d ostorlab.co "
+        "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json "
+        f"-r {_DNSX_RESOLVERS} -d ostorlab.co "
         "-w agent/wordlists/100_list.txt",
         stdout='{"host":"www.ostorlab.co","resolver":["1.0.0.1:53","8.8.8.8:53","8.8.4.4:53","1.1.1.1:53"],'
         '"a":["164.90.232.184","3.67.255.218"],'
@@ -208,6 +232,8 @@ def testAgentDnsx_withDomainScopeArgAndDomainMessageNotInScope_targetShouldNotBe
             "-mx",
             "-resp",
             "-json",
+            "-r",
+            _DNSX_RESOLVERS,
             "-l",
             fp.any(max=1),
         ],
@@ -218,7 +244,8 @@ def testAgentDnsx_withDomainScopeArgAndDomainMessageNotInScope_targetShouldNotBe
         '"has_internal_ips":false,"status_code":"NOERROR","timestamp":"2022-04-05T17:25:59.876762366+02:00"}',
     )
     fp.register(
-        "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json -d ostorlab.co "
+        "dnsx -silent -a -aaaa -cname -ns -txt -ptr -mx -resp -json "
+        f"-r {_DNSX_RESOLVERS} -d ostorlab.co "
         "-w agent/wordlists/100_list.txt",
         stdout='{"host":"www.ostorlab.co","resolver":["1.0.0.1:53","8.8.8.8:53","8.8.4.4:53","1.1.1.1:53"],'
         '"a":["164.90.232.184","3.67.255.218"],'


### PR DESCRIPTION
### Summary
Configure dnsx with explicit Cloudflare, Google, and Quad9 resolvers, excluding OpenDNS to prevent court-order notices from being emitted as TXT records.

### Changes
Add -r to direct and wordlist-based dnsx commands.
Update existing command tests.
